### PR TITLE
respect go environment variables

### DIFF
--- a/Formula/buf.rb
+++ b/Formula/buf.rb
@@ -10,6 +10,7 @@ class Buf < Formula
 
   def install
     ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
+    ENV["GOENV"] = HOMEBREW_CACHE/"../../../Library/Application Support/go/env"
     system "sh", "make/buf/scripts/brew.sh", ".build/brew"
     prefix.install Dir[".build/brew/*"]
   end


### PR DESCRIPTION
For countries that `https://proxy.golang.org` is blocked, the users would use `GOPROXY` to download packages.
But homebrew does not allow the installer to access user's environment variables, so `GOPROXY` will fallback to `https://proxy.golang.org`, which will fail the install.

This workaround set `GOENV` to the path pointing to the user's env file, so that `go build` can use the `GOPROXY`
environment variable.

For your information:

go will read env from `os.UserConfigDir()/go/en` (see https://golang.org/design/30411-env). For a homebrew formula,
this path is something like: `/private/tmp/buf-20210311-46207-lhs3uc/buf-0.39.1/.brew_home/Library/Application Support/go/env`.

Obviously, the file does not exist, and the user's `GOPROXY` is not available to the formula.

The workaround in this commit won't work if:
1. the user's env file is not located at the hardcoded path; or
2. homebrew blocks path like `../../` in the future.

Note: homebrew filters all environment variables to avoid environment contamination (see https://github.com/Homebrew/brew/issues/932). Maybe this workaround is not a good idea. Maybe we should report this issue to homebrew, and see whether it will add something like `go_proxy` to its `*_proxy` family.

The alternative is to document that the users can modify their local formula file `/usr/local/Homebrew/Library/Taps/bufbuild/homebrew-buf/Formula/buf.rb` to specify `GOPROXY`:

```diff
 class Buf < Formula
   desc "A new way of working with Protocol Buffers."
   homepage "https://buf.build"
   head "https://github.com/bufbuild/buf.git"
   url "https://github.com/bufbuild/buf/archive/v0.39.1.tar.gz"
   sha256 "7608c5ad489d1d11c80230b6a4e5f55aa9a64351f0fff7e52a3dbadfbac6925d"
   version "0.39.1"

   depends_on "go" => :build

   def install
     ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
+    ENV["GOPROXY"] = "https://goproxy.cn,direct"
     system "sh", "make/buf/scripts/brew.sh", ".build/brew"
     prefix.install Dir[".build/brew/*"]
   end

   test do
     system "#{bin}/buf --version"
   end
 end
```