### PR TITLE
TCN-664 automate homebrew-buf release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         id: generate_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: 251311
+          app_id: 257240
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
           repository: ${{ github.repository }}
           permissions: >-
@@ -51,7 +51,7 @@ jobs:
         id: generate_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: 251311
+          app_id: 257240
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
           repository: ${{ github.repository }}
           permissions: >-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,74 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: The version you intend to release (eg x.y.z)
+  pull_request:
+    types: [ closed ]
+
+env:
+  VERSION: ${{ github.event.inputs.version }}
+
+jobs:
+  perform:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version != '' }}
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: 251311
+          private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
+          repository: ${{ github.repository }}
+          permissions: >-
+            {"contents": "write", "pull_requests": "write"}
+      - name: Checkout repository code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+      - name: Update Buf
+        run: bash update.bash "${VERSION}"
+      - name: Create PR
+        id: cpr
+        uses: peter-evans/create-pull-request@ad43dccb4d726ca8514126628bec209b8354b6dd
+        with:
+          add-paths: .
+          commit-message: "Update version to v${{env.VERSION}}"
+          branch: release/v${{env.VERSION}}
+          delete-branch: true
+          title: "Release v${{env.VERSION}}"
+          body: |
+            Release performed for ${{env.VERSION}}
+          token: ${{ steps.generate_token.outputs.token }}
+  update-master:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release')
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: 251311
+          private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
+          repository: ${{ github.repository }}
+          permissions: >-
+            {"contents": "write"}
+      - name: Set VERSION variable from tag
+        run: |
+          VERSION=${{github.head_ref}}
+          echo "VERSION=${VERSION##*/}" >> $GITHUB_ENV
+      - name: Checkout repository code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          fetch-depth: 0
+      - name: Update master
+        run: |
+          # we keep master around because homebrew cannot deal with the rename
+          git switch master
+          git pull origin master
+          git merge main
+          git push origin master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ on:
 
 env:
   VERSION: ${{ github.event.inputs.version }}
+  APP_ID: 257240
 
 jobs:
   perform:
@@ -20,7 +21,7 @@ jobs:
         id: generate_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: 257240
+          app_id: ${{env.APP_ID}}
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
           repository: ${{ github.repository }}
           permissions: >-
@@ -51,7 +52,7 @@ jobs:
         id: generate_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: 257240
+          app_id: ${{env.APP_ID}}
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
           repository: ${{ github.repository }}
           permissions: >-

--- a/Formula/buf.rb
+++ b/Formula/buf.rb
@@ -2,9 +2,9 @@ class Buf < Formula
   desc "A new way of working with Protocol Buffers."
   homepage "https://buf.build"
   head "https://github.com/bufbuild/buf.git", branch: "main"
-  url "https://github.com/bufbuild/buf/archive/v0.0.2.tar.gz"
-  sha256 "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed"
-  version "0.0.2"
+  url "https://github.com/bufbuild/buf/archive/v1.9.0.tar.gz"
+  sha256 "d80360b347d799beffbc98aa528d18bf6e6c6ac38a0222a51c028d816db30d20"
+  version "1.9.0"
 
   depends_on "go" => :build
 

--- a/Formula/buf.rb
+++ b/Formula/buf.rb
@@ -2,9 +2,9 @@ class Buf < Formula
   desc "A new way of working with Protocol Buffers."
   homepage "https://buf.build"
   head "https://github.com/bufbuild/buf.git", branch: "main"
-  url "https://github.com/bufbuild/buf/archive/v1.9.0.tar.gz"
-  sha256 "d80360b347d799beffbc98aa528d18bf6e6c6ac38a0222a51c028d816db30d20"
-  version "1.9.0"
+  url "https://github.com/bufbuild/buf/archive/v0.0.2.tar.gz"
+  sha256 "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed"
+  version "0.0.2"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
Automates the two-step process of releasing this asset. 
## `perform`:
```sh
cd "${BUFBUILD_HOMEBREW_BUF_DIR}"
git switch main
git pull origin main

bash update.bash "${VERSION}"
git diff

git checkout -b release/v${VERSION}
git commit -am "Update to v${VERSION}"
git push origin release/v${VERSION}

# Get that PR approved and merged
```

## `update-master`:

```sh
git switch main
git pull origin main
# we keep master around because homebrew cannot deal with the rename
git switch master
git pull origin master
git merge main
git push origin master
```

