### PR TITLE
Update buf to use binary releases

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -7,7 +7,6 @@ on:
         description: The version you intend to release (eg x.y.z)
 env:
   VERSION: ${{ github.event.inputs.version }}
-  APP_ID: 257240
 jobs:
   perform:
     runs-on: ubuntu-latest
@@ -18,27 +17,36 @@ jobs:
         run: |
           echo "error: buf version must not start with 'v'."
           exit 1
-      - name: Get GitHub app token
-        uses: actions/create-github-app-token@v1
-        id: app_token
-        with:
-          app-id: ${{ env.APP_ID }}
-          private-key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
       - name: Checkout repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          token: ${{ steps.app_token.outputs.token }}
-      - name: Update Buf
-        run: bash update.bash "${VERSION}"
-      - name: Create PR
+          path: base
+      - name: Update formula
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-          BRANCH="release/v${VERSION}"
-          git switch -C ${BRANCH}
-          git add .
-          git commit -m "Update version to ${VERSION}"
-          git push --set-upstream origin --force ${BRANCH} 
-          gh pr create --title "Release v${VERSION}" --body "Release prepared for ${VERSION}"
-        env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          # Darwin arm64
+          curl -LO https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-Darwin-arm64
+          SHA256=$(shasum -a 256 buf-Darwin-arm64 | awk '{print $1}')
+          sed -i "s/version \".*\"/version \"$VERSION\"/" base/Formula/buf.rb
+          sed -i "s/sha256 \".*\"/sha256 \"$SHA256\"/" base/Formula/buf.rb
+          sed -i "s/\"darwin-arm64\" => \".*\"/\"darwin-arm64\" => \"$SHA256\"/" base/Formula/buf.rb
+          # Darwin x86_64
+          curl -LO https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-Darwin-x86_64
+          SHA256=$(shasum -a 256 buf-Darwin-x86_64 | awk '{print $1}')
+          sed -i "s/\"darwin-x86_64\" => \".*\"/\"darwin-x86_64\" => \"$SHA256\"/" base/Formula/buf.rb
+          # Linux arm64
+          curl -LO https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-Linux-aarch64
+          SHA256=$(shasum -a 256 buf-Linux-aarch64 | awk '{print $1}')
+          sed -i "s/\"linux-arm64\" => \".*\"/\"linux-arm64\" => \"$SHA256\"/" base/Formula/buf.rb
+          # Linux x86_64
+          curl -LO https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-Linux-x86_64
+          SHA256=$(shasum -a 256 buf-Linux-x86_64 | awk '{print $1}')
+          sed -i "s/\"linux-x86_64\" => \".*\"/\"linux-x86_64\" => \"$SHA256\"/" base/Formula/buf.rb
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: Update buf to v${{ github.event.inputs.version }}
+          title: Update buf to v${{ github.event.inputs.version }}
+          body: |
+            Update buf to v${{ github.event.inputs.version }}
+          branch: update-buf-${{ github.event.inputs.version }}
+          path: base

--- a/Formula/buf.rb
+++ b/Formula/buf.rb
@@ -1,15 +1,15 @@
 class Buf < Formula
   desc "The best way of working with Protocol Buffers."
   homepage "https://buf.build"
-  version "1.48.0"
+  version "1.50.0"
   url "https://github.com/bufbuild/buf/releases/download/v#{version}/buf-Darwin-arm64"
-  sha256 "6ef7df6116c72ef3ccaa8574c9b8008389f0911c1921da4689e0abff3924a4bd"
+  sha256 "4a215517d0bcb37c47b9178e2668d7651a7fef9a482cef482227ad09796cdfc0"
 
   checksums = {
-    "darwin-arm64" => "6ef7df6116c72ef3ccaa8574c9b8008389f0911c1921da4689e0abff3924a4bd",
-    "darwin-x86_64" => "5af7155250ad8af5f0a2f5701d1df83bfece53dfe98f13b3768d808468fcdbde",
-    "linux-arm64" => "76b531e2c29be3b0ddf8b1034126b56506532b47c98b3968a49f09432536f39d",
-    "linux-x86_64" => "30cbac88a3cdda6e48dcf727f3cf9d2669d771c5d5be94f37e202c76a522b66e",
+    "darwin-arm64" => "4a215517d0bcb37c47b9178e2668d7651a7fef9a482cef482227ad09796cdfc0",
+    "darwin-x86_64" => "baaf26b33519fe4494729aab9b02cea449a134ed028b5c21d16ca42734da76e4",
+    "linux-arm64" => "5d630153d4d7aae1093f964ed15f1391ce9288f2d4192a4818c18443b3565bbf",
+    "linux-x86_64" => "154ea883ce098eac4fa106ff9ee4e4964bb97f809dd8ec9c34a432b466ce1494",
   }
 
   on_macos do

--- a/Formula/buf.rb
+++ b/Formula/buf.rb
@@ -1,17 +1,41 @@
 class Buf < Formula
   desc "The best way of working with Protocol Buffers."
   homepage "https://buf.build"
-  head "https://github.com/bufbuild/buf.git", branch: "main"
-  url "https://github.com/bufbuild/buf/archive/v1.50.0.tar.gz"
-  sha256 "8ef886f4793bc76abc91da41a2ab87666bb5bfef86ddbb95e7f8240b8978c1df"
-  version "1.50.0"
+  version "1.48.0"
+  url "https://github.com/bufbuild/buf/releases/download/v#{version}/buf-Darwin-arm64"
+  sha256 "6ef7df6116c72ef3ccaa8574c9b8008389f0911c1921da4689e0abff3924a4bd"
 
-  depends_on "go" => :build
+  checksums = {
+    "darwin-arm64" => "6ef7df6116c72ef3ccaa8574c9b8008389f0911c1921da4689e0abff3924a4bd",
+    "darwin-x86_64" => "5af7155250ad8af5f0a2f5701d1df83bfece53dfe98f13b3768d808468fcdbde",
+    "linux-arm64" => "76b531e2c29be3b0ddf8b1034126b56506532b47c98b3968a49f09432536f39d",
+    "linux-x86_64" => "30cbac88a3cdda6e48dcf727f3cf9d2669d771c5d5be94f37e202c76a522b66e",
+  }
+
+  on_macos do
+    on_arm do
+      url "https://github.com/bufbuild/buf/releases/download/v#{version}/buf-Darwin-arm64"
+      sha256 checksums["darwin-arm64"]
+    end
+    on_intel do
+      url "https://github.com/bufbuild/buf/releases/download/v#{version}/buf-Darwin-x86_64"
+      sha256 checksums["darwin-x86_64"]
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/bufbuild/buf/releases/download/v#{version}/buf-Linux-aarch64"
+      sha256 checksums["linux-arm64"]
+    end
+    on_intel do
+      url "https://github.com/bufbuild/buf/releases/download/v#{version}/buf-Linux-x86_64"
+      sha256 checksums["linux-x86_64"]
+    end
+  end
 
   def install
-    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
-    system "sh", "make/buf/scripts/brew.sh", ".build/brew"
-    prefix.install Dir[".build/brew/*"]
+    bin.install "buf-#{OS.kernel_name}-#{Hardware::CPU.arch}" => "buf"
   end
 
   test do


### PR DESCRIPTION
This updates the buf formula to download the binary from GitHub releases. The release workflow has been updated to generate the new Formula.

Fixes https://github.com/bufbuild/homebrew-buf/issues/16