### PR TITLE
Update the setup-homebrew action to use `@main` and set HOMEBREW_DEVELOPER=1 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - main
+env:
+  HOMEBREW_DEVELOPER: 1
+
 jobs:
   darwin-arm64:
     runs-on: macos-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
       - run: brew install --build-from-source Formula/buf.rb
       - run: buf --version


### PR DESCRIPTION
The homebrew actions have been updated to use
`main` as their default branch, updating to match.

Also, the latest releases of `brew` will refuse to install
a formula without a tap unless `HOMEBREW_DEVELOPER=1`
is set in the env, so this is now set in CI.