### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00" # UTC


### PR DESCRIPTION
Slowly getting out of date here, and Node 20 used by some of our actions will go EoL soon.